### PR TITLE
create a docker container for reproducible model inference

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,8 @@
+FROM nvidia/cuda:11.6.0-base-ubuntu20.04
+RUN apt update
+RUN apt install -y pip python curl
+RUN pip install torch==1.9.0
+RUN pip install numpy>=1.18.2
+RUN pip install tqdm
+RUN apt install -y git
+RUN git clone https://github.com/labdao/RefineGNN.git

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -2,6 +2,7 @@ FROM nvidia/cuda:11.6.0-base-ubuntu20.04
 RUN apt update
 RUN apt install -y pip python curl
 RUN pip install torch==1.9.0
+# no simple way to install torch==1.8.2 LTS from pip
 RUN pip install numpy>=1.18.2
 RUN pip install tqdm
 RUN apt install -y git


### PR DESCRIPTION
Hi Wengong, 

I read the RefineGNN paper today and would love to run it within a docker container. I created a dockerfile that I hope fulfills the installation requirements. 
One thing I noticed was a difficulty around installing torch==1.8.2 - the long term support version seems to be not available via pip install. Have you seen this problem, too? I simply used torch==1.9.0 in this build - It seems like one might get more lucky using a conda version of pytorch-lts if 1.8.2 is a strict requirement. 

How have you installing torch==1.8.2? 